### PR TITLE
Include X-Hub-Signature-256 for compatibility

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -38,6 +38,7 @@ const signature = createHmacSignature(data);
 axios.post(url, data, {
   headers: {
     "X-Hub-Signature": signature,
+    "X-Hub-Signature-256": "sha256=" + signature,
     "X-Hub-SHA": process.env.GITHUB_SHA
   }
 }).then(function () {


### PR DESCRIPTION
Classic Github Webhooks use 2 signature headers. 
Github uses 2 signature headers: the SHA-1 X-Hub-Signature header and the new SHA256 X-Hub-Signature-256 header (https://docs.github.com/en/enterprise-server@3.0/developers/webhooks-and-events/securing-your-webhooks#validating-payloads-from-github).
The X-Hub-Signature here contains SHA256 instead of SHA-1 and it is probably not a good idea to fix it because it may break peoples workflows, but I propose to add the correct X-Hub-Signature-256 header to improve compatibity with classic Github Webhooks.